### PR TITLE
Fix included Vagrantfile

### DIFF
--- a/box/Vagrantfile
+++ b/box/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
-#VAGRANTFILE_API_VERSION = "2"
+VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Every Vagrant virtual environment requires a box to build off of.
@@ -22,5 +22,4 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Copy the user's .gitconfig (if it exists) so they don't
   # have to reconfigure Git in the VM:
   config.vm.provision "file", source: "~/.gitconfig", destination: "/home/vagrant/.gitconfig"
-
 end


### PR DESCRIPTION
Hi :)

I got this error:

```
$ vagrant up
There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

Path: /Users/vassilevsky/.vagrant.d/boxes/cbumgard-VAGRANTSLASH-golang/0.1.0/virtualbox/Vagrantfile
Message: uninitialized constant VAGRANTFILE_API_VERSION
```

This patch fixed it for me.

<3
